### PR TITLE
akka artifact updates

### DIFF
--- a/taxonomy-batch/pom.xml
+++ b/taxonomy-batch/pom.xml
@@ -64,20 +64,20 @@
 
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-actor_2.11</artifactId>
-            <version>2.3.9</version>
+            <artifactId>akka-actor_2.12</artifactId>
+            <version>2.5.18</version>
         </dependency>
 
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-remote_2.11</artifactId>
-            <version>2.3.9</version>
+            <artifactId>akka-remote_2.12</artifactId>
+            <version>2.5.18</version>
         </dependency>
 
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-testkit_2.11</artifactId>
-            <version>2.3.9</version>
+            <artifactId>akka-testkit_2.12</artifactId>
+            <version>2.5.18</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Updates to akka version including fix to vulnerability notified at: https://nvd.nist.gov/vuln/detail/CVE-2017-1000034.  N.B. Following this change, the application still builds using maven from the command line, though only excluding the test (I found this was also true for the current master so an unrelated issue).  I have though successfully run all the tests manually from within Intellij.