### PR TITLE
Update pom.xml for xstream

### DIFF
--- a/taxonomy-common/pom.xml
+++ b/taxonomy-common/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
-			<version>1.4.4</version>
+			<version>1.4.11.1</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Updated xstream (com.thoughtworks.xstream) to version 1.4.11.1 to address security vulnerability - https://nvd.nist.gov/vuln/detail/CVE-2013-7285